### PR TITLE
More sophisticated build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # s4-wormhole-convergence-agent
+
 The convergence agent for the magic-wormhole-enabled S4 signup process.
+
+## Building
+
+Easiest way is to build
+with [stack](https://docs.haskellstack.org/en/stable/README/).
+
+```console
+$ stack build
+```

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,22 @@
+name: s4-wormhole-convergence-agent
+version: 0.1.0
+synopsis: The convergence agent for the magic-wormhole-enabled S4 signup process.
+description: Please see README.md
+maintainer: Jean-Paul Calderone <exarkun@twistedmatrix.org>
+license: MIT
+github: LeastAuthority/s4-wormhole-convergence-agent
+category: Web
+
+ghc-options: -Wall -Werror
+
+dependencies:
+  - base >= 4.9 && < 5
+
+executables:
+  wsmain:
+    main: wsmain.hs
+    dependencies:
+      - aeson
+      - bytestring
+      - text
+      - websockets

--- a/s4-wormhole-convergence-agent.cabal
+++ b/s4-wormhole-convergence-agent.cabal
@@ -1,0 +1,31 @@
+-- This file has been generated from package.yaml by hpack version 0.15.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           s4-wormhole-convergence-agent
+version:        0.1.0
+synopsis:       The convergence agent for the magic-wormhole-enabled S4 signup process.
+description:    Please see README.md
+category:       Web
+homepage:       https://github.com/LeastAuthority/s4-wormhole-convergence-agent#readme
+bug-reports:    https://github.com/LeastAuthority/s4-wormhole-convergence-agent/issues
+maintainer:     Jean-Paul Calderone <exarkun@twistedmatrix.org>
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
+
+source-repository head
+  type: git
+  location: https://github.com/LeastAuthority/s4-wormhole-convergence-agent
+
+executable wsmain
+  main-is: wsmain.hs
+  ghc-options: -Wall -Werror
+  build-depends:
+      base >= 4.9 && < 5
+    , aeson
+    , bytestring
+    , text
+    , websockets
+  default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-8.9
+
+packages:
+  - .


### PR DESCRIPTION
Requires having [stack](https://docs.haskellstack.org/en/stable/README/), which might be more effort than you're willing to go to right now.

The idea is that `package.yaml` is the main file for configuring the project. The `.cabal` file is generated, and you might be able to get away with not keeping it in git, but most projects I've seen still do.